### PR TITLE
Adding markdown viewer and dock layout in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,7 +596,6 @@ Platforms supported by each .NET MAUI control are listed below.
 		Yes<br/>
 		</td>
 	</tr>
-
     <tr>  
 	    <td rowspan="2" valign="top">
 	    MISCELLANEOUS<br/>

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Platforms supported by each .NET MAUI control are listed below.
 		</td>
 	</tr>
     <tr>
-	    <td rowspan="2" valign="top">
+	    <td rowspan="3" valign="top">
 			LAYOUT<br/>
 		</td>	
 		<td>
@@ -295,6 +295,23 @@ Platforms supported by each .NET MAUI control are listed below.
 	<tr>
 		<td>
 			<a href="https://help.syncfusion.com/maui/parallax-view/overview">Parallax View</a><br/>
+		</td>
+		<td>
+		Yes<br/>
+		</td>
+		<td>
+		Yes<br/>
+		</td>
+		<td>
+		Yes<br/>
+		</td>
+		<td>
+		Yes<br/>
+		</td>
+	</tr>
+		<tr>
+		<td>
+			<a href="https://help.syncfusion.com/maui/docklayout/overview">DockLayout</a><br/>
 		</td>
 		<td>
 		Yes<br/>

--- a/README.md
+++ b/README.md
@@ -576,6 +576,27 @@ Platforms supported by each .NET MAUI control are listed below.
 		Yes<br/>
 		</td>
 	</tr>
+	    <tr>  
+	    <td rowspan="1" valign="top">
+	    VIEWER<br/>
+		</td>
+		<td>
+			<a href="https://help.syncfusion.com/maui/markdownviewer/overview">Markdown Viewer</a><br/>
+		</td>
+		<td>
+		Yes<br/>
+		</td>
+		<td>
+		Yes<br/>
+		</td>
+		<td>
+		Yes<br/>
+		</td>
+		<td>
+		Yes<br/>
+		</td>
+	</tr>
+
     <tr>  
 	    <td rowspan="2" valign="top">
 	    MISCELLANEOUS<br/>


### PR DESCRIPTION
### Description 

Adding markdown viewer and dock layout in README 

<img width="1051" height="883" alt="image" src="https://github.com/user-attachments/assets/5fc0869b-bd9f-4433-b724-e2f1b3598d8b" />
